### PR TITLE
Unbold page numbers (and chapters) in TOC

### DIFF
--- a/USCthesis.sty
+++ b/USCthesis.sty
@@ -944,6 +944,9 @@
   \pdfbookmark{Table of Contents}{Table of Contents}
   \chapter*{Table of Contents}%
   \begin{singlespace}
+    % The style guide specifies page numbers should not be bold.
+    % Default is normal for sections, but bold for chapters.
+    \let\bfseries\mdseries
     \vskip -1em
     \@starttoc{toc}%
   \end{singlespace}


### PR DESCRIPTION
The current guidelines as of June 2022 (https://graduateschool.usc.edu/wp-content/uploads/2020/11/Manuscript_Formatting_and_Documentation_Styles.pdf) specify that the page numbers in the table of contents should not be bold.

In the example TOC included in the guidelines, nothing is bold (names or numbers).

Implements this in a hacky way, but it works. I tried the `tocloft` package but it had no effect and ruined the single spacing.