### PR TITLE
Fix: Every TOC entry has leading dots to page num.

### DIFF
--- a/USCthesis.sty
+++ b/USCthesis.sty
@@ -959,9 +959,18 @@
 % ---calvin 2022-06-16
 \iftocbold
     \renewcommand{\cftchapfont}{\bfseries}
+    
+    % change the weight of the dots
+    \renewcommand{\cftchapleader}{\bfseries\cftdotfill{\cftchapdotsep}} 
 \else
     \renewcommand{\cftchapfont}{\mdseries}
+    
+    % change the weight of the dots
+    \renewcommand{\cftchapleader}{\mdseries\cftdotfill{\cftchapdotsep}}
 \fi
+
+\renewcommand\cftchapdotsep{\cftdotsep}	   % add dots in between capter names
+                                           % and page numbers
 
 \renewcommand{\cftchappagefont}{\mdseries} % page numbers should always
                                            %   be non-bold


### PR DESCRIPTION
USC thesis guidelines require "Every entry on the TOC needs leading dots going to each page number."

Added `tocloft` commands to include dots for chapters based on the chapter font styles, bold or medium-weight.